### PR TITLE
Fix correlated matching boundary component handling

### DIFF
--- a/src/pymatching/sparse_blossom/driver/user_graph.h
+++ b/src/pymatching/sparse_blossom/driver/user_graph.h
@@ -321,8 +321,12 @@ void iter_dem_instructions_include_correlations(
                         "Encountered a decomposed error instruction with an undetectable component (0 detectors). "
                         "This is not supported.");
                 } else if (num_component_detectors > 0) {
-                    // If the previous error in the decomposition had 1 or 2 detectors, we handle it
-                    handle_dem_error(p, {component->node1, component->node2}, component->observable_indices);
+                    // If the previous error in the decomposition had 1 or 2 detectors, we handle it.
+                    if (component->node2 == SIZE_MAX) {
+                        handle_dem_error(p, {component->node1}, component->observable_indices);
+                    } else {
+                        handle_dem_error(p, {component->node1, component->node2}, component->observable_indices);
+                    }
                     decomposed_err.components.push_back({});
                     component = &decomposed_err.components.back();
                     component->node1 = SIZE_MAX;

--- a/tests/matching/decode_test.py
+++ b/tests/matching/decode_test.py
@@ -400,6 +400,26 @@ def test_decode_to_edges_with_correlations():
     assert np.array_equal(edges, expected_edges)
 
 
+def test_correlated_matching_handles_single_detector_components():
+    stim = pytest.importorskip("stim")
+    p = 0.1
+    circuit = stim.Circuit.generated(
+        code_task="surface_code:rotated_memory_x",
+        distance=5,
+        rounds=5,
+        before_round_data_depolarization=p,
+    )
+    circ_str = str(circuit).replace(
+        f"DEPOLARIZE1({p})", f"PAULI_CHANNEL_1(0, {p}, 0)"
+    )
+    noisy_circuit = stim.Circuit(circ_str)
+    dem = noisy_circuit.detector_error_model(
+        decompose_errors=True, approximate_disjoint_errors=True
+    )
+    m = Matching.from_detector_error_model(dem, enable_correlations=True)
+    assert m.num_detectors > 0
+
+
 def test_load_from_circuit_with_correlations():
     stim = pytest.importorskip("stim")
     circuit = stim.Circuit.generated(


### PR DESCRIPTION
## Summary
- fix handling of decomposed DEM components with a single detector when building correlated matching graphs
- prevent spurious SIZE_MAX endpoints from being passed as second detector in intermediate components
- add regression test covering PAULI_CHANNEL_1 Y-only noise under correlated matching

## Testing
- pytest tests/matching/decode_test.py -k single_detector -vv
- pytest tests/matching/decode_test.py -k correlations -vv

------
https://chatgpt.com/codex/tasks/task_e_68d477fd31b08320a62bdb85387dc6b9